### PR TITLE
Remove organic from products

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -6,7 +6,7 @@ class ProductsController < ApplicationController
   end
 
   def product_params
-    params.require(:product).permit(:name, :picture, :origin, :cultural_history, :vegan, :gluten_free, :dairy_free, :organic, 
+    params.require(:product).permit(:name, :picture, :origin, :cultural_history, :vegan, :gluten_free, :dairy_free, 
                                     :lc_based, :fair, :eco_sound, :humane, :upc, :vendor_id,
                                     certification_ids: [],
                                     certifications_attributes: [:name, :id, :_destroy],
@@ -17,7 +17,7 @@ class ProductsController < ApplicationController
   end
 
   def product_params_without_nested
-    params.require(:product).permit(:name, :origin, :cultural_history, :vegan, :gluten_free, :dairy_free, :organic,
+    params.require(:product).permit(:name, :origin, :cultural_history, :vegan, :gluten_free, :dairy_free,
                                     :lc_based, :fair, :eco_sound, :humane, :upc, :vendor_id,
                                     certification_ids: [],
                                     nutrition_ids: [],

--- a/app/views/products/_form.html.haml
+++ b/app/views/products/_form.html.haml
@@ -30,9 +30,6 @@
       .checkboxClass
         = f.label :vegan
         = f.check_box :vegan
-      .checkboxClass
-        = f.label :organic
-        = f.check_box :organic
     .form_group.element_div#rfc_div
       %h4 Real Food Challenge
       .checkboxClass

--- a/db/migrate/20190419041847_remove_organic_from_products.rb
+++ b/db/migrate/20190419041847_remove_organic_from_products.rb
@@ -1,0 +1,5 @@
+class RemoveOrganicFromProducts < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :products, :organic, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_12_224145) do
+ActiveRecord::Schema.define(version: 2019_04_19_041847) do
 
   create_table "certifications", force: :cascade do |t|
     t.string "name"
@@ -78,15 +78,8 @@ ActiveRecord::Schema.define(version: 2019_04_12_224145) do
     t.datetime "updated_at", null: false
     t.text "origin"
     t.text "cultural_history"
-    t.boolean "organic"
     t.string "picture"
     t.index ["vendor_id"], name: "index_products_on_vendor_id"
-  end
-
-  create_table "tags", force: :cascade do |t|
-    t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "vendor_ownerships", force: :cascade do |t|
@@ -96,15 +89,6 @@ ActiveRecord::Schema.define(version: 2019_04_12_224145) do
     t.datetime "updated_at", null: false
     t.index ["ownership_id"], name: "index_vendor_ownerships_on_ownership_id"
     t.index ["vendor_id"], name: "index_vendor_ownerships_on_vendor_id"
-  end
-
-  create_table "vendor_tags", force: :cascade do |t|
-    t.bigint "tag_id"
-    t.bigint "vendor_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["tag_id"], name: "index_vendor_tags_on_tag_id"
-    t.index ["vendor_id"], name: "index_vendor_tags_on_vendor_id"
   end
 
   create_table "vendors", force: :cascade do |t|

--- a/spec/factories/product.rb
+++ b/spec/factories/product.rb
@@ -7,7 +7,6 @@ FactoryBot.define do
 		vegan {true}
 		gluten_free {false}
 		dairy_free {false}
-    	organic {false}
 		lc_based {false}
 		fair {false}
 		eco_sound {false}


### PR DESCRIPTION
This addresses the chore to move organic into certifications, and includes a new migration to remove organic, removes organic from view, controller, and factory.