### PR TITLE
Fixed dropdown content bug to not go off the right side of page

### DIFF
--- a/app/assets/stylesheets/addPage.scss
+++ b/app/assets/stylesheets/addPage.scss
@@ -101,6 +101,9 @@ $gray-color: #BEBEBE;
 
 .dropdown:hover .dropdown-content {
   display: block;
+  left:auto; 
+  right:0;
+
 }
 
 .dropdown {

--- a/app/assets/stylesheets/addPage.scss
+++ b/app/assets/stylesheets/addPage.scss
@@ -103,7 +103,6 @@ $gray-color: #BEBEBE;
   display: block;
   left:auto; 
   right:0;
-
 }
 
 .dropdown {


### PR DESCRIPTION
This fixes the dropdown bug, so that on an expanded page, the content does not overflow off the page