### PR TITLE
Fix nav mobile

### DIFF
--- a/app/assets/stylesheets/addPage.scss
+++ b/app/assets/stylesheets/addPage.scss
@@ -220,11 +220,6 @@ justify-content: center;
   color: $unselected-color;
 }
 
-#logo {
-  height: 129px;
-  width: 135px;
-}
-
 // Discovery Page Header
 
 #logoheader {

--- a/app/assets/stylesheets/discovery.scss
+++ b/app/assets/stylesheets/discovery.scss
@@ -100,16 +100,6 @@
   line-height: 80px;
 }
 
-/*@media (min-width: 100px) {
-.navbar-brand.abs
-    {
-        position: absolute;
-        width: 100%;
-        left: 0;
-        text-align: center;
-    }
-}*/
-
 .navbar-toggle {
   margin-top: 23px;
   padding: 9px 10px !important;

--- a/app/views/application/_header.html.haml
+++ b/app/views/application/_header.html.haml
@@ -1,8 +1,8 @@
 %header
-  %div{:class => "navbar navbar-expand-md navbar-dark bg-dark static-top"}
+  %div{:class => "navbar navbar-expand-lg navbar-dark bg-dark static-top"}
     %div{:class => "container-fluid"}
       %div{:class => "navbar-header"}
-        = link_to discovery_path, id: "logo", class: "navbar-brand w-50" do
+        = link_to discovery_path, class: "navbar-brand w-50" do
           = image_tag "logo450x429.png", id: "logoheader"
       %button{:type => "button", :class => "navbar-toggler", :data => {:toggle => "collapse", :target => "#navbarResponsive"}, :aria => {:expanded => "false", :controls => "navbarResponsive", :label => "Toggle navigation"}}
         %span{:class => "navbar-toggler-icon"}

--- a/app/views/application/_header.html.haml
+++ b/app/views/application/_header.html.haml
@@ -2,7 +2,7 @@
   %div{:class => "navbar navbar-expand-lg navbar-dark bg-dark static-top"}
     %div{:class => "container-fluid"}
       %div{:class => "navbar-header"}
-        = link_to discovery_path, class: "navbar-brand w-50" do
+        = link_to discovery_path, id: "logo", class: "navbar-brand w-50" do
           = image_tag "logo450x429.png", id: "logoheader"
       %button{:type => "button", :class => "navbar-toggler", :data => {:toggle => "collapse", :target => "#navbarResponsive"}, :aria => {:expanded => "false", :controls => "navbarResponsive", :label => "Toggle navigation"}}
         %span{:class => "navbar-toggler-icon"}


### PR DESCRIPTION
Attempt to change bootstrap class to expand-lg, so that on mobile it defaults to a collapse menu
Also removed #logo css class that was messing with the navbar sizing