### PR TITLE
Fix small bug in Product Details page

### DIFF
--- a/app/views/products/_details_extend_tags.haml
+++ b/app/views/products/_details_extend_tags.haml
@@ -1,6 +1,5 @@
-- if @tags.length > 0
+- if @tags.length > (4 - @rfc.length)
   %h3.tagLinks Tags: 
-  - if @tags.length > (4 - @rfc.length)
-    - @tags[4 - @rfc.length...@tags.length].each do |tag|
-      %h3.tagLinks
-        = tag.name
+  - @tags[4 - @rfc.length...@tags.length].each do |tag|
+    %h3.tagLinks
+      = tag.name


### PR DESCRIPTION
Before, even if there weren't enough tags to overflow to below the Product photo, the gray "Tags:" text would still appear. This is a small fix so that text only appears when they are extra tags to display.