### PR TITLE
Delete button

### DIFF
--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -75,4 +75,14 @@ class Admin::ProductsController < ApplicationController
       product_fail("update", product)
     end
   end
+
+  def destroy
+    product = Product.find(params[:id])
+    success = product.destroy
+    if success
+      product_success("delete")
+    else
+      product_fail("delete", product)
+    end
+  end
 end

--- a/app/controllers/admin/vendors_controller.rb
+++ b/app/controllers/admin/vendors_controller.rb
@@ -70,7 +70,7 @@ class Admin::VendorsController < ApplicationController
 
   def destroy
     vendor = Vendor.find(params[:id])
-    success = Vendor.destroy
+    success = vendor.destroy
     if success
       vendor_success("delete")
     else

--- a/app/controllers/admin/vendors_controller.rb
+++ b/app/controllers/admin/vendors_controller.rb
@@ -67,4 +67,14 @@ class Admin::VendorsController < ApplicationController
       vendor_fail("update", vendor)
     end
   end
+
+  def destroy
+    vendor = Vendor.find(params[:id])
+    success = Vendor.destroy
+    if success
+      vendor_success("delete")
+    else
+      vendor_fail("delete", vendor)
+    end
+  end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -12,12 +12,12 @@ class Product < ActiveRecord::Base
 
   belongs_to :vendor
 
-  has_many :product_certifications
-  has_many :certifications, through: :product_certifications
-  has_many :product_nutritions
-  has_many :nutritions, through: :product_nutritions
-  has_many :product_packagings
-  has_many :packagings, through: :product_packagings
+  has_many :product_certifications, dependent: :destroy
+  has_many :certifications, through: :product_certifications, dependent: :destroy
+  has_many :product_nutritions, dependent: :destroy
+  has_many :nutritions, through: :product_nutritions, dependent: :destroy
+  has_many :product_packagings, dependent: :destroy
+  has_many :packagings, through: :product_packagings, dependent: :destroy
 
   accepts_nested_attributes_for :certifications, :allow_destroy => true
   accepts_nested_attributes_for :nutritions, :allow_destroy => true

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -8,9 +8,9 @@ class Vendor < ActiveRecord::Base
   end
   validates :name, presence: true, uniqueness: true
 
-  has_many :products
-  has_many :vendor_ownerships
-  has_many :ownerships, through: :vendor_ownerships
+  has_many :products, dependent: :destroy
+  has_many :vendor_ownerships, dependent: :destroy
+  has_many :ownerships, through: :vendor_ownerships, dependent: :destroy
 
   accepts_nested_attributes_for :ownerships, :allow_destroy => true
 

--- a/app/views/admin/products/_form.html.haml
+++ b/app/views/admin/products/_form.html.haml
@@ -99,5 +99,6 @@
 
     .form_group#submit_div
       = f.submit class: 'btn btn-success'
-      = button_to 'Delete', admin_product_path, {method: :delete, data: {confirm: 'Are you sure you want to delete this product?'}, class: 'btn btn-danger'}
+      -if @product.persisted?
+        = button_to 'Delete', admin_product_path, {method: :delete, data: {confirm: 'Are you sure you want to delete this product?'}, class: 'btn btn-danger', id: :delete_button}
       = button_tag 'Cancel', type: :button, onclick: 'confirmProductCancel()', id: :cancel_button, class: 'btn btn-warning'

--- a/app/views/admin/products/_form.html.haml
+++ b/app/views/admin/products/_form.html.haml
@@ -99,4 +99,5 @@
 
     .form_group#submit_div
       = f.submit class: 'btn btn-success'
-      = button_tag 'Cancel', type: :button, onclick: 'confirmProductCancel()', id: :cancel_button, class: 'btn btn-danger'
+      = button_to 'Delete', admin_product_path, {method: :delete, data: {confirm: 'Are you sure you want to delete this product?'}, class: 'btn btn-danger'}
+      = button_tag 'Cancel', type: :button, onclick: 'confirmProductCancel()', id: :cancel_button, class: 'btn btn-warning'

--- a/app/views/admin/products/_form.html.haml
+++ b/app/views/admin/products/_form.html.haml
@@ -100,5 +100,5 @@
     .form_group#submit_div
       = f.submit class: 'btn btn-success'
       -if @product.persisted?
-        = button_to 'Delete', admin_product_path, {method: :delete, data: {confirm: 'Are you sure you want to delete this product?'}, class: 'btn btn-danger', id: :delete_button}
+        = link_to 'Delete', admin_product_path, {method: :delete, data: {confirm: 'Are you sure you want to delete this product?'}, class: 'btn btn-danger', id: :delete_button}
       = button_tag 'Cancel', type: :button, onclick: 'confirmProductCancel()', id: :cancel_button, class: 'btn btn-warning'

--- a/app/views/admin/vendors/_form.html.haml
+++ b/app/views/admin/vendors/_form.html.haml
@@ -54,5 +54,5 @@
     #submit_div.form_group
       = f.submit class: 'btn btn-success'
       -if @vendor.persisted?
-        = button_to 'Delete', admin_vendor_path, {method: :delete, data: {confirm: 'Are you sure you want to delete this vendor?'}, class: 'btn btn-danger', id: :delete_button}
+        = link_to 'Delete', admin_vendor_path, {method: :delete, data: {confirm: 'Are you sure you want to delete this vendor?'}, class: 'btn btn-danger', id: :delete_button}
       = button_tag 'Cancel', type: :button, onclick: 'confirmVendorCancel()', id: :cancel_button, class: 'btn btn-warning'

--- a/app/views/admin/vendors/_form.html.haml
+++ b/app/views/admin/vendors/_form.html.haml
@@ -53,4 +53,6 @@
 
     #submit_div.form_group
       = f.submit class: 'btn btn-success'
+      -if @vendor.persisted?
+        = button_to 'Delete', admin_vendor_path, {method: :delete, data: {confirm: 'Are you sure you want to delete this vendor?'}, class: 'btn btn-danger', id: :delete_button}
       = button_tag 'Cancel', type: :button, onclick: 'confirmVendorCancel()', id: :cancel_button, class: 'btn btn-danger'

--- a/app/views/admin/vendors/_form.html.haml
+++ b/app/views/admin/vendors/_form.html.haml
@@ -55,4 +55,4 @@
       = f.submit class: 'btn btn-success'
       -if @vendor.persisted?
         = button_to 'Delete', admin_vendor_path, {method: :delete, data: {confirm: 'Are you sure you want to delete this vendor?'}, class: 'btn btn-danger', id: :delete_button}
-      = button_tag 'Cancel', type: :button, onclick: 'confirmVendorCancel()', id: :cancel_button, class: 'btn btn-danger'
+      = button_tag 'Cancel', type: :button, onclick: 'confirmVendorCancel()', id: :cancel_button, class: 'btn btn-warning'

--- a/app/views/application/_singleSymbolItems.html.haml
+++ b/app/views/application/_singleSymbolItems.html.haml
@@ -8,6 +8,10 @@
           - path = {controller: "admin/#{myclass.name.downcase}s", action: "edit", id: item.id}
         - else
           - path = {controller: "#{myclass.name.downcase}s", action: "show", id: item.id}
-        = button_to "#{item.name}", path, {method: :get, class: 'prod-link'}
+        -if "#{myclass.name.downcase}" == "tag"
+          .prod-link 
+            = item.name
+        -else
+          = button_to "#{item.name}", path, {method: :get, class: 'prod-link'}
 - else
   %tr{id: "#{sym}"}

--- a/features/delete_product.feature
+++ b/features/delete_product.feature
@@ -22,4 +22,4 @@ Feature: Delete a product
     Then I should be on the volunteer-facing products index page
     And I should see a success message
     And no products should exist
-    And no tags should be deleted
+    And no product tags should be deleted

--- a/features/delete_product.feature
+++ b/features/delete_product.feature
@@ -10,7 +10,7 @@ Feature: Delete a product
   Scenario: Delete a product without tags
     Given a product already exists
     And I am on the edit product page
-    When I press "Delete"
+    When I follow "Delete"
     Then I should be on the volunteer-facing products index page
     And I should see a success message
     And no products should exist
@@ -18,7 +18,7 @@ Feature: Delete a product
   Scenario: Delete a product with tags
     Given a product with tags already exists
     And I am on the edit product page
-    When I press "Delete"
+    When I follow "Delete"
     Then I should be on the volunteer-facing products index page
     And I should see a success message
     And no products should exist

--- a/features/delete_product.feature
+++ b/features/delete_product.feature
@@ -1,0 +1,25 @@
+Feature: Delete a product
+  
+  As a volunteer,
+  I want to be able to delete a product
+  So I can remove outdated or incorrect products
+  
+  Background:
+    Given a vendor already exists
+  
+  Scenario: Delete a product without tags
+    Given a product already exists
+    And I am on the edit product page
+    When I press "Delete"
+    Then I should be on the volunteer-facing products index page
+    And I should see a success message
+    And no products should exist
+    
+  Scenario: Delete a product with tags
+    Given a product with tags already exists
+    And I am on the edit product page
+    When I press "Delete"
+    Then I should be on the volunteer-facing products index page
+    And I should see a success message
+    And no products should exist
+    And no tags should be deleted

--- a/features/delete_vendor.feature
+++ b/features/delete_vendor.feature
@@ -7,7 +7,7 @@ Feature: Delete a vendor
   Scenario: Delete a vendor without tags
     Given a vendor already exists
     And I am on the edit vendor page
-    When I press "Delete"
+    When I follow "Delete"
     Then I should be on the volunteer-facing vendors index page
     And I should see a success message
     And no vendors should exist
@@ -15,7 +15,7 @@ Feature: Delete a vendor
   Scenario: Delete a vendor with tags
     Given a vendor with a tag already exists
     And I am on the edit vendor page
-    When I press "Delete"
+    When I follow "Delete"
     Then I should be on the volunteer-facing vendors index page
     And I should see a success message
     And no vendors should exist
@@ -25,7 +25,7 @@ Feature: Delete a vendor
     Given a vendor with a tag already exists
     And a product with tags already exists
     And I am on the edit vendor page
-    When I press "Delete"
+    When I follow "Delete"
     Then I should be on the volunteer-facing vendors index page
     And I should see a success message
     And no vendors should exist

--- a/features/delete_vendor.feature
+++ b/features/delete_vendor.feature
@@ -1,0 +1,34 @@
+Feature: Delete a vendor
+  
+  As a volunteer,
+  I want to be able to delete a vendor
+  So I can remove outdated or incorrect vendor
+  
+  Scenario: Delete a vendor without tags
+    Given a vendor already exists
+    And I am on the edit vendor page
+    When I press "Delete"
+    Then I should be on the volunteer-facing vendors index page
+    And I should see a success message
+    And no vendors should exist
+  
+  Scenario: Delete a vendor with tags
+    Given a vendor with a tag already exists
+    And I am on the edit vendor page
+    When I press "Delete"
+    Then I should be on the volunteer-facing vendors index page
+    And I should see a success message
+    And no vendors should exist
+    And no vendor tags should be deleted
+  
+  Scenario: Delete a vendor with products
+    Given a vendor with a tag already exists
+    And a product with tags already exists
+    And I am on the edit vendor page
+    When I press "Delete"
+    Then I should be on the volunteer-facing vendors index page
+    And I should see a success message
+    And no vendors should exist
+    And no products should exist
+    And no vendor tags should be deleted
+    And no product tags should be deleted

--- a/features/step_definitions/helper_steps.rb
+++ b/features/step_definitions/helper_steps.rb
@@ -1,5 +1,5 @@
 When /I submit the form/ do
-  page.find('input[type="submit"]').click
+  page.find('.btn-success').click
 end
 
 When /I include a bad picture/ do

--- a/features/step_definitions/product_steps.rb
+++ b/features/step_definitions/product_steps.rb
@@ -201,6 +201,8 @@ Then /no products should exist/ do
   expect(Product.count).to eq(0)
 end
 
-Then /no tags should be deleted/ do
-  expect(Tag.count).to eq(3)
+Then /no product tags should be deleted/ do
+  expect(Certification.count).to eq(1)
+  expect(Nutrition.count).to eq(1)
+  expect(Packaging.count).to eq(1)
 end

--- a/features/step_definitions/product_steps.rb
+++ b/features/step_definitions/product_steps.rb
@@ -200,3 +200,7 @@ end
 Then /no products should exist/ do
   expect(Product.count).to eq(0)
 end
+
+Then /no tags should be deleted/ do
+  expect(Tag.count).to eq(3)
+end

--- a/features/step_definitions/vendor_steps.rb
+++ b/features/step_definitions/vendor_steps.rb
@@ -109,3 +109,7 @@ Then /I should see the photo, mission, story, and social media of the vendor/ do
   expect(page.find("#story")).not_to be nil
   expect(page.find("#socialWithText")).not_to be nil
 end
+
+Then /no vendor tags should be deleted/ do
+  expect(Ownership.count).to eq(1)
+end


### PR DESCRIPTION
This adds a delete button to both vendor and product submission edit forms.
It does not add a delete button to the new forms.
We updated the models to support deletion.
We updated the admin controllers to have a destroy action.
We updated the views to have the button on the forms.
*And we made it so the admin facing tags index page does not route when tag is clicked on